### PR TITLE
Prevent silent errors when no SPF record is found

### DIFF
--- a/src/steps/validate-spf-record.ts
+++ b/src/steps/validate-spf-record.ts
@@ -21,8 +21,10 @@ export class ValidateSpfRecord extends BaseStep implements StepInterface {
     const spfParse = require('spf-parse');
     const stepData: any = step.getData().toJavaScript();
     const domain: string = stepData.domain;
+    const prefixes: string[] = ['~all', '-all'];
     let records: any[];
     const parsedRecords: SpfRecord[] = [];
+    let lastEntry: any;
 
     try {
       records = await this.client.findSpfRecordByDomain(domain);
@@ -33,8 +35,10 @@ export class ValidateSpfRecord extends BaseStep implements StepInterface {
       return this.error('There was a problem checking the domain: %s', [e.toString()]);
     }
 
-    const lastEntry:any = parsedRecords[0].mechanisms[parsedRecords[0].mechanisms.length - 1];
-    const prefixes: string[] = ['~all', '-all'];
+    // Wrap to prevent error outcomes with no response.
+    if (parsedRecords[0]) {
+      lastEntry = parsedRecords[0].mechanisms[parsedRecords[0].mechanisms.length - 1];
+    }
 
     if (records.length !== 1) {
       // If record has more than 1 record, return a fail.


### PR DESCRIPTION
Possible fix for #5, although I was not able to reproduce the issue there with those specific domains.

This appears to be necessary when: a domain exists and is valid, but there are no text / SPF records.