### PR TITLE
Provide friendlier errors

### DIFF
--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -49,8 +49,15 @@ export class ClientWrapper {
       try {
         this.client.resolveTxt(domain, (err, results) => {
           if (err) {
-            reject(err);
-            return;
+            // Friendlier errors for known situations.
+            if (err['code'] === 'ENOTFOUND') {
+              return reject(new Error(`Domain ${domain} does not exist.`));
+            }
+            if (err['code'] === 'ENODATA') {
+              return resolve([]);
+            }
+
+            return reject(err);
           }
 
           const result: any = [];

--- a/src/steps/validate-spf-record.ts
+++ b/src/steps/validate-spf-record.ts
@@ -1,10 +1,11 @@
 import { Message } from './../models/message';
 import { Mechanism } from '../models/mechanism';
 import { SpfRecord } from './../models/spf-record';
-/*tslint:disable:no-else-after-return*/
-
 import { BaseStep, Field, StepInterface } from '../core/base-step';
 import { Step, RunStepResponse, FieldDefinition, StepDefinition } from '../proto/cog_pb';
+
+/*tslint:disable:no-else-after-return*/
+/*tslint:disable:max-line-length*/
 
 export class ValidateSpfRecord extends BaseStep implements StepInterface {
 
@@ -25,6 +26,7 @@ export class ValidateSpfRecord extends BaseStep implements StepInterface {
     let records: any[];
     const parsedRecords: SpfRecord[] = [];
     let lastEntry: any;
+    let actualText: string;
 
     try {
       records = await this.client.findSpfRecordByDomain(domain);
@@ -42,34 +44,27 @@ export class ValidateSpfRecord extends BaseStep implements StepInterface {
 
     if (records.length !== 1) {
       // If record has more than 1 record, return a fail.
-      // tslint:disable-next-line:max-line-length
-      return this.fail('There should only be 1 SPF record for %s, but there were actually %s', [domain, records.length.toString()]);
-    // tslint:disable-next-line:max-line-length
+      actualText = records.length ? `${records.length}:\n\n${records.map(r => r.join('')).join('\n')}` : records.length.toString();
+      return this.fail('There should only be 1 SPF record for %s, but there were actually %s', [domain, actualText]);
     } else if (parsedRecords[0].mechanisms.filter((mechanism: Mechanism) => mechanism.type === 'include' || mechanism.type === 'a' || mechanism.type === 'mx' || mechanism.type === 'ptr' || mechanism.type === 'exists').length > 10) {
       // If record has more than 10 lookups, return a fail.
-      // tslint:disable-next-line:max-line-length
-      const mechanismLength: string = parsedRecords[0].mechanisms.filter((mechanism: Mechanism) => mechanism.type === 'include' || mechanism.type === 'a' || mechanism.type === 'mx' || mechanism.type === 'ptr' || mechanism.type === 'exists').length.toString();
-      // tslint:disable-next-line:max-line-length
-      return this.fail('There should only be no more than 10 SPF lookups for %s, but there were actually %s', [domain, mechanismLength]);
+      const applicableMechanisms = parsedRecords[0].mechanisms.filter((mechanism: Mechanism) => mechanism.type === 'include' || mechanism.type === 'a' || mechanism.type === 'mx' || mechanism.type === 'ptr' || mechanism.type === 'exists');
+      const mechanismLength: string = applicableMechanisms.length.toString();
+      actualText = `${mechanismLength}:\n\n${applicableMechanisms.map(m => `${m.type}:${m.value}`).join('\n')}`;
+      return this.fail('There should be no more than 10 SPF lookups for %s, but there were actually %s', [domain, actualText]);
     } else if (records[0].find((record: any) => record.toString().length > 255)) {
       // If record has more than 255 characters, return a fail.
       const invalidStringTxt = records.find((record: any) => record.toString().length > 255);
-      // tslint:disable-next-line:max-line-length
       return this.fail('SPF record for %s includes a string over 255 characters. Consider breaking this up into multiple strings: %s', [domain, invalidStringTxt]);
     } else if (records[0].join('').length > 512) {
       // If record has more than 512 bytes, return a fail.
-      // tslint:disable-next-line:max-line-length
-      return this.fail("SPF records shouldn't exceed 512 bytes, but %s's record was %s bytes", [domain, records[0].join('').length]);
-    // tslint:disable-next-line:max-line-length
+      return this.fail("SPF records shouldn't exceed 512 bytes, but %s's record was %s bytes: %s", [domain, records[0].join('').length, records[0].join('')]);
     } else if (parsedRecords[0].messages != null && parsedRecords[0].messages.filter((message: Message) => message.type === 'error').length > 0) {
       // If record has a syntax error, return a fail.
-      // tslint:disable-next-line:max-line-length
       const errors = parsedRecords[0].messages.filter((message: Message) => message.type === 'error');
-      // tslint:disable-next-line:max-line-length
       return this.fail("Found syntax error(s) in %s's SPF record: %s", [domain, errors.map(e => e.message).join('\n')]);
     } else if (!prefixes.includes(lastEntry.prefix + lastEntry.type)) {
       // If record's last entry is not ~all, return a fail.
-      // tslint:disable-next-line:max-line-length
       return this.fail('The last entry in an SPF record should be -all or ~all, but it was actually %s', [lastEntry.prefix + lastEntry.type]);
     } else {
       // If record passes all criteria, return a pass.

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -51,6 +51,34 @@ describe('ClientWrapper', () => {
     .to.be.rejectedWith(anError);
   });
 
+  it('findSpfRecordByDomain:apiError:enodata', async () => {
+    const sampleDomain = 'anyDomain';
+    const anError = new Error('An API Error');
+
+    // Set up test instance.
+    anError['code'] = 'ENODATA';
+    dnsStub.resolveTxt.callsArgWith(1, anError);
+    clientWrapperUnderTest = new ClientWrapper(dnsStub);
+
+    // Call the method and make assertions.
+    const actualResult = await clientWrapperUnderTest.findSpfRecordByDomain(sampleDomain);
+    expect(actualResult).to.deep.equal([]);
+  });
+
+  it('findSpfRecordByDomain:apiError:enotfound', async () => {
+    const sampleDomain = 'anyDomain';
+    const anError = new Error('An API Error');
+
+    // Set up test instance.
+    anError['code'] = 'ENOTFOUND';
+    dnsStub.resolveTxt.callsArgWith(1, anError);
+    clientWrapperUnderTest = new ClientWrapper(dnsStub);
+
+    // Call the method and make assertions.
+    return expect(clientWrapperUnderTest.findSpfRecordByDomain(sampleDomain))
+      .to.be.rejected;
+  });
+
   it('findSpfRecordByDomain:apiThrows', async () => {
     const sampleDomain = 'anyDomain';
     const anError = new Error('An API Error');

--- a/test/steps/validate-spf-record.ts
+++ b/test/steps/validate-spf-record.ts
@@ -94,7 +94,7 @@ describe('ValidateSpfRecordStep', () => {
   it('should respond with fail if API client returns with a single Spf record has more than 10 mechanisms of specific types', async () => {
     // Stub a response that matches expectations.
     const domainInput: string = 'sampleDomain.com';
-    const expectedResponseMessage: string = 'There should only be no more than 10 SPF lookups for %s, but there were actually %s';
+    const expectedResponseMessage: string = 'There should be no more than 10 SPF lookups for %s, but there were actually %s';
     const expectedSpfRecord: any = [
       [
         'v=spf1 include:_spf.google.com ~all include:_spf.google.com ~all include:_spf.google.com ~all include:_spf.google.com ~all include:_spf.google.com ~all include:_spf.google.com ~all include:_spf.google.com ~all include:_spf.google.com ~all include:_spf.google.com ~all include:_spf.google.com ~all include:_spf.google.com ~all',
@@ -150,7 +150,7 @@ describe('ValidateSpfRecordStep', () => {
   it('should respond with fail if API client returns with a single Spf record has more than 512 bytes', async () => {
     // Stub a response that matches expectations.
     const domainInput: string = 'sampleDomain.com';
-    const expectedResponseMessage: string = "SPF records shouldn't exceed 512 bytes, but %s's record was %s bytes";
+    const expectedResponseMessage: string = "SPF records shouldn't exceed 512 bytes, but %s's record was %s bytes: %s";
     const expectedSpfRecord: any = [
       [
         'v=spf1 include:_spf.google.com ~all include:_spf.google.com ~all include:_spf.google.com ~all include:_spf.google.com ~all include:_spf.google.com ~all include:_spf.google.com ~all',


### PR DESCRIPTION
- Allows step code to account for when there is no SPF data
- Highlight (through error) when a domain does not exist